### PR TITLE
docs: Bazel credential helper example

### DIFF
--- a/github.com/mrmod/README.md
+++ b/github.com/mrmod/README.md
@@ -1,0 +1,63 @@
+# Examples : A Bazel Credential Helper
+
+A [Bazel credential helper](https://blog.engflow.com/2023/10/09/configuring-bazels-credential-helper/) allows configuring authorization headers (or any HTTP headers) for requests sent to remote urls.
+
+Credential Helpers which `exit 0` put a JSON document of a map of header names to header values
+```
+{
+    "Authorization": "Bearer SecureData",
+    "CSRF": "SecureMark",
+    "KeyId": "PublicKeyId"
+}
+```
+
+A Go example [bazel credential helper](./bazelcredentialhelper/) exchanges `CLIENT_CREDENTIAL` with [a credential store](./credentialstore/) for its `SERVICE_TOKEN`.
+
+```
+BAZEL_WORKSPACE=/path/to/bazel/project
+
+echo "Starting credential store"
+pushd credentialstore ; SERVICE_TOKEN=serviceToken CLIENT_CREDENTIAL=clientCredential go run main.go &; popd
+
+echo "Starting credentialed service Bazel will call"
+pushed credentialservice ; SERVICE_TOKEN=serviceToken go run main.go & ; popd
+
+echo "Building and installing `localhost-credential-helper` to BAZEL_WORKSPACE"
+pushed bazelcredentialhelper ; go build -o localhost-credential-helper main.go ; cp localhost-credential-helper $BAZEL_WORKSPACE ; popd
+
+```
+
+After that's started, you can use it from the `BAZEL_WORKSPACE`:
+
+```
+# .bazelrc
+common --credential_helper=/Users/bruce/Development/homewatch/localhost-credential-helper
+
+# WORKSPACE
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "localhost_demo",
+    sha256 = "InvalidChecksum",
+    urls = [
+        "http://localhost:8080/artifacts/localhost_demo.zip",
+    ],
+)
+```
+Then
+```
+CLIENT_CREDENTIAL=clientCredential bazel fetch @localhost_demo//...
+```
+
+Watch the [credential store](./credentialstore/) log for the credential exchange attempt and then the request for the `http_archive` `urls` artifact `/artifacts/localhost_demo.zip`.
+
+# CredentialedService
+
+An HTTP Service which reads an `Authorization` HTTP header and splits it on `Bearer ` (with a trailing whitespace) optional set with `VALID_TOKNEN`.
+
+# CredentialStore
+
+A HTTP Service which exchanges a received `CLIENT_CREDENTIAL` a client knows with a `SERVICE_TOKEN` it knows over the `/` HTTP route and artifacts over the `/artifacts/${Artifact}` route given a `SERVICE_TOKEN`-authorized request.
+
+# BazelCredentialHelper
+
+An HTTP Client which sends an env `CLIENT_CREDENTIAL` value to `localhost:8080` and exits with a JSON document of authorized headers as expected by the Bazel experimental Credential Helper interface.

--- a/github.com/mrmod/bazelcredentialhelper/main.go
+++ b/github.com/mrmod/bazelcredentialhelper/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+type BazelCredentialHelperData struct {
+	Headers map[string][]string `json:"headers"`
+}
+
+const (
+	envClientCredential = "CLIENT_CREDENTIAL"
+)
+
+var (
+	clientCredential = "123"
+)
+
+func main() {
+
+	if _clientCredential, ok := os.LookupEnv(envClientCredential); ok {
+		log.Printf("Using client credential from environment variable %s", envClientCredential)
+		clientCredential = _clientCredential
+	}
+	log.Println("Exchanging `CLIENT_CREDENTIAL` '" + clientCredential + "' with credential store")
+	res, err := http.DefaultClient.Do(&http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Scheme: "http", Host: "localhost:8080"},
+		Header: http.Header{
+			"Authorization": []string{"Bearer " + clientCredential},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Status: %d", res.StatusCode)
+
+	defer res.Body.Close()
+	credentialStoreResponse := map[string]string{}
+	if err := json.NewDecoder(res.Body).Decode(&credentialStoreResponse); err != nil {
+		log.Fatalf("Failed to decode credential store response: %s", err)
+	}
+
+	serviceToken := credentialStoreResponse["message"]
+	log.Println("Got `SERVICE_TOKEN` '" + serviceToken + "' from credential store by exchanging `CLIENT_CREDENTIAL`")
+
+	c, err := json.MarshalIndent(BazelCredentialHelperData{
+		Headers: map[string][]string{
+			"Authorization": []string{"Bearer " + serviceToken},
+		},
+	}, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s", c)
+}

--- a/github.com/mrmod/credentialstore/main.go
+++ b/github.com/mrmod/credentialstore/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	envServiceToken     = "SERVICE_TOKEN"
+	envClientCredential = "CLIENT_CREDENTIAL"
+)
+
+var (
+	serviceToken     = "123"
+	clientCredential = "abc"
+)
+
+func main() {
+
+	if _serviceToken, ok := os.LookupEnv(envServiceToken); ok {
+		log.Printf("Using service token '%s' from environment variable %s", _serviceToken, envServiceToken)
+		serviceToken = _serviceToken
+	}
+
+	if _clientCredential, ok := os.LookupEnv(envClientCredential); ok {
+		log.Printf("Using client credential '%s' from environment variable %s", _clientCredential, envClientCredential)
+		clientCredential = _clientCredential
+	}
+	log.Println("Starting credentialStore service...")
+
+	// Service requiring a service token
+	http.HandleFunc("/artifacts/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Authorizing artifact by `SERVICE_TOKEN`: %s", r.URL.Path)
+		authorizationHeader := r.Header.Get("Authorization")
+		log.Printf("Headers: %#v", r.Header)
+		token := strings.TrimSpace(strings.Split(authorizationHeader, "Bearer ")[1])
+		if token != serviceToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		log.Printf("Serving artifact: %s", r.URL.Path)
+		http.StripPrefix(
+			"/artifacts/",
+			http.FileServer(http.Dir("artifacts/")),
+		).ServeHTTP(w, r)
+	})
+
+	// ClientCredential to serviceToken exchange handler
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+
+		authorizationHeader := r.Header.Get("Authorization")
+
+		if s := strings.Split(authorizationHeader, "Bearer "); len(s) == 2 {
+			credential := strings.TrimSpace(s[1])
+			log.Printf("Client sent credential: '%s'", credential)
+			if credential == clientCredential {
+				log.Printf("Exchanged clientCredential '%s' for serviceToken '%s'", credential, serviceToken)
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, "{\"message\":\"%s\"}", serviceToken)
+				return
+			}
+		}
+		log.Printf("Invalid clientCredential Authorization header: %s", authorizationHeader)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This adds a small example of bazel credential helper providing a client which bazel executes and a service which an organization would run.