### PR TITLE
example: HttpTransport mocking

### DIFF
--- a/github.com/mrmod/README.md
+++ b/github.com/mrmod/README.md
@@ -61,3 +61,9 @@ A HTTP Service which exchanges a received `CLIENT_CREDENTIAL` a client knows wit
 # BazelCredentialHelper
 
 An HTTP Client which sends an env `CLIENT_CREDENTIAL` value to `localhost:8080` and exits with a JSON document of authorized headers as expected by the Bazel experimental Credential Helper interface.
+
+# HttpTransportInjector
+
+An example of how to test third-party HTTP APIs are getting the proper requests from your code and that your code is handling its responses correctly.
+
+Demonstrates an `http.DefaultClient.Transport` dependency injection for integration testing against third-party APIs without making remote calls.

--- a/github.com/mrmod/httptransportinjector/main.go
+++ b/github.com/mrmod/httptransportinjector/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+)
+
+/*
+An example of replacing the Transport on the `http.DefaultClient` to
+allow for tesing requests and responses
+*/
+
+func doRequest(httpUrl string) (*http.Response, error) {
+
+	req, err := http.NewRequest("GET", httpUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
+func sendRequest(httpUrl, data string) (*http.Response, error) {
+	req, err := http.NewRequest("POST", httpUrl, bytes.NewBufferString(data))
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}

--- a/github.com/mrmod/httptransportinjector/main_test.go
+++ b/github.com/mrmod/httptransportinjector/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// playbackTripper is a http.RoundTripper that replays the same response
+// for every request.
+type playbackTripper struct {
+	response   []byte
+	statusCode int
+}
+
+// inputTripper is a http.RoundTripper that replays the same response
+// for every request
+// and validates the request body
+type inputTripper struct {
+	playbackTripper
+	request []byte
+}
+
+// RoundTrip implements http.RoundTripper.
+// It returns the same response for every request.
+func (p playbackTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: p.statusCode,
+		Body:       io.NopCloser(bytes.NewBuffer(p.response)),
+	}, nil
+}
+
+// RoundTrip implements http.RoundTripper.
+// It validates the request body and returns the same response for every request.
+// It returns `200` when the request body matches the expected request body
+func (i inputTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	inputRequest, _ := io.ReadAll(r.Body)
+	if string(inputRequest) != string(i.request) {
+		return (&playbackTripper{
+			response:   i.response,
+			statusCode: i.playbackTripper.statusCode,
+		}).RoundTrip(r)
+	}
+
+	return (&playbackTripper{response: i.response, statusCode: http.StatusOK}).RoundTrip(r)
+}
+
+func TestDoRequestWithInput(t *testing.T) {
+	defaultTransport := http.DefaultClient.Transport
+	defer func() {
+		http.DefaultClient.Transport = defaultTransport
+	}()
+	expectedResponse := []byte("RecordedResponsePlayback")
+	expectedRequest := []byte("ExpectedRequest")
+	http.DefaultClient.Transport = inputTripper{
+		request: expectedRequest,
+		playbackTripper: playbackTripper{
+			response:   expectedResponse,
+			statusCode: http.StatusBadRequest,
+		},
+	}
+
+	response, err := sendRequest("http://example.com", string(expectedRequest)+"cat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("Expected %d : BadRequest, got %d", http.StatusBadRequest, response.StatusCode)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != string(expectedResponse) {
+		t.Fatalf("Expected %s, got %s", expectedResponse, body)
+	}
+}
+
+func TestDoRequestWithPlayback(t *testing.T) {
+	defaultTransport := http.DefaultClient.Transport
+	defer func() {
+		http.DefaultClient.Transport = defaultTransport
+	}()
+
+	expectedResponse := []byte("RecordedResponsePlayback")
+	http.DefaultClient.Transport = playbackTripper{
+		response:   expectedResponse,
+		statusCode: http.StatusOK,
+	}
+
+	response, err := doRequest("http://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != string(expectedResponse) {
+		t.Fatalf("Expected %s, got %s", expectedResponse, body)
+	}
+}
+
+func TestDoRequest(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, "TestResponse")
+			}),
+	)
+
+	// http.DefaultClient.Transport = server
+
+	defer server.Close()
+
+	resp, err := doRequest(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "TestResponse\n" {
+		t.Fatalf("Expected %s, got %s", "TestResponse", string(body))
+	}
+}


### PR DESCRIPTION
A illustrative example of the value of interfaces in creating testable software.

In this example, the `http.DefaultClient.Transport` `http.RoundTripper` interface is replaced with a function which returns our bytes as the body and our status code, regardless of the URL the public or private code is trying to call.

When the client utilizes the `http.DefaultClient` we can then test fully the integration of the HTTP request and response handling in our code.