### PR TITLE
chore: Docs/readability

### DIFF
--- a/github.com/mrmod/homewatch/README.md
+++ b/github.com/mrmod/homewatch/README.md
@@ -10,6 +10,12 @@ Releases can be deployed to a aystem for testing
 ./release.sh
 ```
 
+This builds the binary `make build-linux Version=${RELEASE_VERSION}`.
+
+Then runs the playbook `setup.playbook.yaml` for the `homewatch` tags with `RELEASE_VERSION=2.0.0-pre-abc123`.
+
+When `SERVICE_RESTART=yes`, the running HomewatchAgent will be killed on the `AGENT_IP` host and the new version started.
+
 ## SFTP Proxy Feature
 
 When an SFTP upload arrives at the Homewatch host (aka: CamerasManagerHost)

--- a/github.com/mrmod/homewatch/setup.playbook.yaml
+++ b/github.com/mrmod/homewatch/setup.playbook.yaml
@@ -15,7 +15,6 @@
       # system: yes
       # cameras123
       password: "{{ 'cameras123' | password_hash('sha512') }}"
-      # password: '$6$rounds=656000$mysecretsalt$WRs1x/pyvZYww89hjn9jEMrAhIOe8PRoY7UAr4dAnj0UT797MKFk/2qdi1vPX4E7fehVikLETN4cr5gQUNmIA.'
 
   - name: Uploader group
     ansible.builtin.template.group:
@@ -75,7 +74,7 @@
       owner: grafana
       group: grafana
       
-  - name: Homewatch start script
+  - name: Deploy start_homewatch.sh
     tags:
       - homewatch
     ansible.builtin.template:


### PR DESCRIPTION
Adds more information about releasing the homewatch-agent. ultralist:47 is the docker follow-on